### PR TITLE
Fix error in zsh: unknown file attribute

### DIFF
--- a/src/_homesick
+++ b/src/_homesick
@@ -37,7 +37,8 @@ _homesick() {
 
   # The general flags accepted by all commands (according to
   # `homesick help SUBCOMMAND`, though not all make sense for the context).
-  local __homesick_genericargs=(
+  local __homesick_genericargs
+  __homesick_genericargs=(
     {-f,--force}'[Overwrite files that already exist]' \
     {-p,--pretend,--no-pretend}'[Run but do not make any changes]' \
     {-q,--quiet,--no-quiet}'[Suppress status output]' \


### PR DESCRIPTION
This completion plugin resulted in an error on my machine:  "unknown file attribute".
Local variables should not be declared on the same line as the "local" keyword.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iamthememory/homesick-zsh-completion/1)
<!-- Reviewable:end -->
